### PR TITLE
Set speakeasy workflow generation mode to direct

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -21,7 +21,7 @@ jobs:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       force: ${{ github.event.inputs.force }}
-      mode: pr
+      mode: direct
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
     secrets:


### PR DESCRIPTION
Use https://www.speakeasyapi.dev/docs/workflow-reference/generation-reference#direct-mode
I've set our push ruleset to Evaluate, to see if we need to add an exception for the push actor for the workflow.